### PR TITLE
ViewModels のテスト

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,6 +45,7 @@ dependencies {
 
     // for test
     testImplementation 'junit:junit:4.12'
+    testImplementation "android.arch.core:core-testing:$test"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:$coroutines_version"
     testImplementation "com.nhaarman.mockitokotlin2:mockito-kotlin:$mockito_kotlin_version"
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'

--- a/app/src/main/java/com/github/mag0716/androidtest/CoroutinesTestTarget.kt
+++ b/app/src/main/java/com/github/mag0716/androidtest/CoroutinesTestTarget.kt
@@ -1,12 +1,14 @@
 package com.github.mag0716.androidtest
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 
-class CoroutinesTestTarget {
-
-    suspend fun loadData(id: Int): String = withContext(Dispatchers.IO) {
+class CoroutinesTestTarget(
+    private val coroutinesDispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
+    suspend fun loadData(id: Int): String = withContext(coroutinesDispatcher) {
         delay(3000)
         "Data$id"
     }

--- a/app/src/main/java/com/github/mag0716/androidtest/ViewModelTestTarget.kt
+++ b/app/src/main/java/com/github/mag0716/androidtest/ViewModelTestTarget.kt
@@ -11,10 +11,8 @@ class ViewModelTestTarget : ViewModel() {
     private val _data = MutableLiveData<String>()
     val data: LiveData<String> = _data
 
-    fun loadData(id: Int) {
-        viewModelScope.launch {
-            val data = CoroutinesTestTarget().loadData(id)
-            _data.value = data
-        }
+    fun loadData(id: Int) = viewModelScope.launch {
+        val data = CoroutinesTestTarget().loadData(id)
+        _data.value = data
     }
 }

--- a/app/src/main/java/com/github/mag0716/androidtest/ViewModelTestTarget.kt
+++ b/app/src/main/java/com/github/mag0716/androidtest/ViewModelTestTarget.kt
@@ -7,10 +7,10 @@ import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.launch
 
 class ViewModelTestTarget : ViewModel() {
-
     private val _data = MutableLiveData<String>()
     val data: LiveData<String> = _data
 
+    // viewModelScope で実行する処理内で suspend fun を使っている場合、完了を知る手段がないので Job を戻り値にする
     fun loadData(id: Int) = viewModelScope.launch {
         val data = CoroutinesTestTarget().loadData(id)
         _data.value = data

--- a/app/src/main/java/com/github/mag0716/androidtest/ViewModelTestTarget.kt
+++ b/app/src/main/java/com/github/mag0716/androidtest/ViewModelTestTarget.kt
@@ -4,15 +4,20 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-class ViewModelTestTarget : ViewModel() {
+class ViewModelTestTarget(
+    private val coroutinesDispatcher: CoroutineDispatcher = Dispatchers.IO
+) : ViewModel() {
     private val _data = MutableLiveData<String>()
     val data: LiveData<String> = _data
 
-    // viewModelScope で実行する処理内で suspend fun を使っている場合、完了を知る手段がないので Job を戻り値にする
-    fun loadData(id: Int) = viewModelScope.launch {
-        val data = CoroutinesTestTarget().loadData(id)
-        _data.value = data
+    fun loadData(id: Int) {
+        viewModelScope.launch {
+            val data = CoroutinesTestTarget(coroutinesDispatcher).loadData(id)
+            _data.value = data
+        }
     }
 }

--- a/app/src/test/java/com/github/mag0716/androidtest/CoroutinesTestRule.kt
+++ b/app/src/test/java/com/github/mag0716/androidtest/CoroutinesTestRule.kt
@@ -3,7 +3,6 @@ package com.github.mag0716.androidtest
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.TestCoroutineScope
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.rules.TestWatcher
@@ -13,8 +12,6 @@ import org.junit.runner.Description
 class CoroutinesTestRule(
     val testDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()
 ) : TestWatcher() {
-
-    val testCoroutineScope = TestCoroutineScope()
 
     override fun starting(description: Description?) {
         super.starting(description)

--- a/app/src/test/java/com/github/mag0716/androidtest/CoroutinesTestRule.kt
+++ b/app/src/test/java/com/github/mag0716/androidtest/CoroutinesTestRule.kt
@@ -1,0 +1,29 @@
+package com.github.mag0716.androidtest
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.TestCoroutineScope
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.rules.TestWatcher
+import org.junit.runner.Description
+
+@ExperimentalCoroutinesApi
+class CoroutinesTestRule(
+    val testDispatcher: TestCoroutineDispatcher = TestCoroutineDispatcher()
+) : TestWatcher() {
+
+    val testCoroutineScope = TestCoroutineScope()
+
+    override fun starting(description: Description?) {
+        super.starting(description)
+        Dispatchers.setMain(testDispatcher)
+    }
+
+    override fun finished(description: Description?) {
+        super.finished(description)
+        Dispatchers.resetMain()
+        testDispatcher.cleanupTestCoroutines()
+    }
+}

--- a/app/src/test/java/com/github/mag0716/androidtest/CoroutinesTestTargetTest.kt
+++ b/app/src/test/java/com/github/mag0716/androidtest/CoroutinesTestTargetTest.kt
@@ -1,15 +1,24 @@
 package com.github.mag0716.androidtest
 
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runBlockingTest
 import org.hamcrest.CoreMatchers.`is`
 import org.junit.Assert
+import org.junit.Rule
 import org.junit.Test
 
+@ExperimentalCoroutinesApi
 class CoroutinesTestTargetTest {
+
+    // テスト対象内で suspend fun を使っている場合に必須
+    @get:Rule
+    var coroutinesTestRule = CoroutinesTestRule()
+
     @Test
-    fun loadTest() = runBlocking {
-        val target = CoroutinesTestTarget()
+    fun loadTest() = coroutinesTestRule.testDispatcher.runBlockingTest {
+        val target = CoroutinesTestTarget(coroutinesTestRule.testDispatcher)
         val data = target.loadData(1)
+        coroutinesTestRule.testDispatcher.advanceTimeBy(4000)
         Assert.assertThat(data, `is`("Data1"))
     }
 }

--- a/app/src/test/java/com/github/mag0716/androidtest/ViewModelTestTargetTest.kt
+++ b/app/src/test/java/com/github/mag0716/androidtest/ViewModelTestTargetTest.kt
@@ -1,0 +1,55 @@
+package com.github.mag0716.androidtest
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import androidx.lifecycle.Observer
+import com.nhaarman.mockitokotlin2.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.TestCoroutineDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnit
+import org.mockito.quality.Strictness
+
+@ExperimentalCoroutinesApi
+class ViewModelTestTargetTest {
+
+    // LiveData を使っている場合に必須
+    @Rule
+    @JvmField
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    @get:Rule
+    val rule = MockitoJUnit.rule().strictness(Strictness.WARN)
+
+    @Mock
+    lateinit var observer: Observer<String>
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(TestCoroutineDispatcher())
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun loadData() = runBlocking {
+        val viewModelTestTarget = ViewModelTestTarget()
+        viewModelTestTarget.data.observeForever(observer)
+
+        // join で完了を待っている
+        // TODO: テストは成功するが、プロダクト側、テスト側にも対応が必要で絶対忘れる
+        viewModelTestTarget.loadData(1).join()
+
+        verify(observer).onChanged("Data1")
+    }
+}

--- a/app/src/test/java/com/github/mag0716/androidtest/ViewModelTestTargetTest.kt
+++ b/app/src/test/java/com/github/mag0716/androidtest/ViewModelTestTargetTest.kt
@@ -4,7 +4,7 @@ import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
 import com.nhaarman.mockitokotlin2.verify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runBlockingTest
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
@@ -30,12 +30,13 @@ class ViewModelTestTargetTest {
     lateinit var observer: Observer<String>
 
     @Test
-    fun loadData() = runBlocking {
-        val viewModelTestTarget = ViewModelTestTarget()
+    fun loadData() = coroutinesTestRule.testDispatcher.runBlockingTest {
+        val viewModelTestTarget = ViewModelTestTarget(coroutinesTestRule.testDispatcher)
         viewModelTestTarget.data.observeForever(observer)
 
-        // join で完了を待っている
-        viewModelTestTarget.loadData(1).join()
+        viewModelTestTarget.loadData(1)
+        // delay されている場合は advanceTimeBy で時間を進める
+        coroutinesTestRule.testDispatcher.advanceTimeBy(4000)
 
         verify(observer).onChanged("Data1")
     }

--- a/app/src/test/java/com/github/mag0716/androidtest/ViewModelTestTargetTest.kt
+++ b/app/src/test/java/com/github/mag0716/androidtest/ViewModelTestTargetTest.kt
@@ -3,14 +3,8 @@ package com.github.mag0716.androidtest
 import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import androidx.lifecycle.Observer
 import com.nhaarman.mockitokotlin2.verify
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.test.TestCoroutineDispatcher
-import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.setMain
-import org.junit.After
-import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.mockito.Mock
@@ -25,21 +19,15 @@ class ViewModelTestTargetTest {
     @JvmField
     val instantTaskExecutorRule = InstantTaskExecutorRule()
 
+    // テスト対象内で suspend fun を使っている場合に必須
+    @get:Rule
+    var coroutinesTestRule = CoroutinesTestRule()
+
     @get:Rule
     val rule = MockitoJUnit.rule().strictness(Strictness.WARN)
 
     @Mock
     lateinit var observer: Observer<String>
-
-    @Before
-    fun setUp() {
-        Dispatchers.setMain(TestCoroutineDispatcher())
-    }
-
-    @After
-    fun tearDown() {
-        Dispatchers.resetMain()
-    }
 
     @Test
     fun loadData() = runBlocking {
@@ -47,7 +35,6 @@ class ViewModelTestTargetTest {
         viewModelTestTarget.data.observeForever(observer)
 
         // join で完了を待っている
-        // TODO: テストは成功するが、プロダクト側、テスト側にも対応が必要で絶対忘れる
         viewModelTestTarget.loadData(1).join()
 
         verify(observer).onChanged("Data1")

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ buildscript {
         coroutines_version = '1.3.2'
         lifecycle_version = '2.2.0-rc01'
         mockito_kotlin_version = "2.2.0"
+        test = "1.1.1"
     }
     repositories {
         google()


### PR DESCRIPTION
## 自分メモ

* テスト対象内で suspend fun を利用していたら、CoroutineDispatcher を差し替える必要がある
* LiveData を利用している場合は、`InstantTaskExecutorRule` を適用する
* delay を使っている場合は、`advanceTimeBy` で擬似的に時間を進める

## 参考

* https://medium.com/@star_zero/livedata%E3%81%AEunittest-2b295d2818c1
* https://speakerdeck.com/hkusu/unit-test-for-viewmodel-and-livedata
* https://developers-jp.googleblog.com/2019/04/android-viewmodelscope.html